### PR TITLE
Added support for CocoaPods

### DIFF
--- a/Notificare/NotificarePushLib/Libraries/MKNetworkKit/NotificareMKNetworkKit.h
+++ b/Notificare/NotificarePushLib/Libraries/MKNetworkKit/NotificareMKNetworkKit.h
@@ -54,18 +54,18 @@
 // ALog always displays output regardless of the DEBUG setting
 #define ALog(fmt, ...) {NSLog((@"%s [Line %d] " fmt), __PRETTY_FUNCTION__, __LINE__, ##__VA_ARGS__);};
 
-#import "Categories/NSString+NotificareMKNetworkKitAdditions.h"
-#import "Categories/NSDictionary+NotificareRequestEncoding.h"
-#import "Categories/NSDate+NotificareRFC1123.h"
-#import "Categories/NSData+NotificareMKBase64.h"
+#import "NSString+NotificareMKNetworkKitAdditions.h"
+#import "NSDictionary+NotificareRequestEncoding.h"
+#import "NSDate+NotificareRFC1123.h"
+#import "NSData+NotificareMKBase64.h"
 
 #if TARGET_OS_IPHONE
-#import "Categories/UIAlertView+NotificareMKNetworkKitAdditions.h"
+#import "UIAlertView+NotificareMKNetworkKitAdditions.h"
 #elif TARGET_OS_MAC
-#import "Categories/NSAlert+NotificareMKNetworkKitAdditions.h"
+#import "NSAlert+NotificareMKNetworkKitAdditions.h"
 #endif
 
-#import "Reachability/NotificareReachability.h"
+#import "NotificareReachability.h"
 
 #import "NotificareMKNetworkOperation.h"
 #import "NotificareMKNetworkEngine.h"

--- a/Notificare/NotificarePushLib/Libraries/MKNetworkKit/NotificareMKNetworkKit.h
+++ b/Notificare/NotificarePushLib/Libraries/MKNetworkKit/NotificareMKNetworkKit.h
@@ -43,6 +43,18 @@
 #endif
 #endif
 
+#if defined(DLog)
+    #undef DLog
+#endif
+
+#if defined(ELog)
+    #undef ELog
+#endif
+
+#if defined(ALog)
+    #undef ALog
+#endif
+
 #ifdef DEBUG
 #   define DLog(fmt, ...) {NSLog((@"%s [Line %d] " fmt), __PRETTY_FUNCTION__, __LINE__, ##__VA_ARGS__);}
 #   define ELog(err) {if(err) DLog(@"%@", err)}

--- a/notificare-push-lib.podspec
+++ b/notificare-push-lib.podspec
@@ -1,0 +1,28 @@
+Pod::Spec.new do |s|
+  s.name         = "notificare-push-lib"
+  s.version      = "0.9.19"
+  s.summary      = "Notificare Push Library for iOS apps"
+  s.description  = <<-DESC
+                   Notificare iOS Library implements the power of smart notifications provided by the Notificare platform in iOS applications.
+
+                   For documentation please refer to: https://notificare.atlassian.net/wiki/display/notificare/Home
+
+                   For support please use: https://notificare.zendesk.com
+                   DESC
+
+  s.homepage     = "https://notifica.re/"
+  s.license      = {
+    :type => 'Commercial',
+    :text => 'All rights reserved'
+  }
+  s.author       = { "Notificare" => "support@notifica.re" }
+  s.platform     = :ios
+  s.source       = { :git => "https://github.com/Notificare/notificare-push-lib.git", :tag => "0.9.19" }
+  s.source_files  = 'Notificare/**/*.h'
+  s.preserve_paths = 'libNotificarePushLib.a'
+  s.resource  = "NotificareResources.bundle"
+  s.libraries = 'NotificarePushLib', 'icucore'
+  s.xcconfig  =  { 'LIBRARY_SEARCH_PATHS' => '"$(PODS_ROOT)/notificare-push-lib"' }
+  s.frameworks = 'CoreLocation', 'MobileCoreServices', 'MessageUI', 'PassKit', 'MapKit', 'SystemConfiguration', 'Security', 'CFNetwork'
+  s.requires_arc = true
+end


### PR DESCRIPTION
I've added preliminary support for [CocoaPods](http://cocoapods.org/). Please review the podspec file and submit it to the master CocoaPods repository. See http://docs.cocoapods.org/guides/contributing_to_the_master_repo.html for more details.

To make the pod work for my project, I've had to make changes in NotificareMKNetworkKit.h. The paths that were included in the #import statements caused the project to break, and the definition of DLog, ELog and ALog macros made some warnings show up, because I had already defined those macros elsewhere in the project. Right now I have simply undefined them, but these macros should probably be removed from the push library altogether.
